### PR TITLE
Handles null input stream and 0 stream size cases.

### DIFF
--- a/fifocache/src/main/java/capital/scalable/droid/fifocache/FIFOCache.java
+++ b/fifocache/src/main/java/capital/scalable/droid/fifocache/FIFOCache.java
@@ -113,7 +113,11 @@ public class FIFOCache {
      * @throws IllegalArgumentException if the provided content's size is 0, or is larger than the size of the cache.
      */
     public File cache(@NonNull Uri uri, String name, long size) throws IOException {
-        return cache(context.getContentResolver().openInputStream(uri), name, size);
+        InputStream inputStream = context.getContentResolver().openInputStream(uri);
+        if (inputStream == null) {
+            throw new IllegalArgumentException("The provided Uri generated a null stream");
+        }
+        return cache(inputStream, name, size);
     }
 
     /**
@@ -127,8 +131,8 @@ public class FIFOCache {
      * @throws IllegalArgumentException if the provided inputStream's size is 0, or is larger than the size of the cache.
      */
     public File cache(@NonNull InputStream inputStream, @NonNull String name, long streamSize) throws IOException {
-        if (streamSize < 0) {
-            throw new IllegalArgumentException("The provided stream size is smaller than 0");
+        if (streamSize <= 0) {
+            throw new IllegalArgumentException("The provided stream size is less than or equal to 0");
         }
         if (streamSize > size) {
             throw new IllegalArgumentException("The provided stream size is larger than the cache");

--- a/fifocache/src/test/java/capital.scalable.droid.fifocache/FIFOCacheUnitTest.kt
+++ b/fifocache/src/test/java/capital.scalable.droid.fifocache/FIFOCacheUnitTest.kt
@@ -64,7 +64,7 @@ class FIFOCacheUnitTest {
     @Test
     fun `caching a file of negative size throws an IllegalArgumentException`() {
         thrown.expect(IllegalArgumentException::class.java)
-        thrown.expectMessage(`is`("The provided stream size is smaller than 0"))
+        thrown.expectMessage(`is`("The provided stream size is less than or equal to 0"))
         cache.cache(inputStream, TEST_FILE, -1)
     }
 


### PR DESCRIPTION
Handles two cases:

1. If the input stream generated from the Uri turns out to be null, throw an IlegalArgumentException.
2. If the streamSize turns out to be 0 or less than 0, throw an IllegalArgumentException.